### PR TITLE
Typo fix in "Patterns of inference"

### DIFF
--- a/chapters/04-patterns-of-inference.md
+++ b/chapters/04-patterns-of-inference.md
@@ -728,7 +728,7 @@ print(expectation(reflectancePosterior))
 viz(reflectancePosterior)
 ~~~~
 
-Now let's condition on the presence of the cylinder, by conditioning on the presence of it's "shadow" (i.e. gaining a noisy observation suggesting that illumination is lower than expected *a priori*):
+Now let's condition on the presence of the cylinder, by conditioning on the presence of its "shadow" (i.e. gaining a noisy observation suggesting that illumination is lower than expected *a priori*):
 
 ~~~~
 var observedLuminance = 3;


### PR DESCRIPTION
"it's" -> "its"