### PR TITLE
fix exercise solution links

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ From the root directory:
 $ scripts/deploy
 ```
 
+Note that you may need to run `$scripts/deploy-to-assets`, depending on what the file is named.
+
 This updates all dependencies and copies them to the assets folder. Note that there are several custom javascript libraries in `assets` that are NOT maintained through nmp: 
 
 * box2d.js

--- a/_layouts/chapter.html
+++ b/_layouts/chapter.html
@@ -27,7 +27,7 @@ custom_css:
 {% assign sorted_pages = site.pages | sort:"chapter_num" %}
 {% assign thisch = false %}
 {% for p in sorted_pages %}
-	{% if thisch %}
+	{% if thisch and p.layout ==  "chapter" %}
 		Next chapter: <a href="{{site.baseurl}}{{p.url}}">{{ p.chapter_num }}. {{ p.title }}</a>
 		{% break %}
 	{% endif %}

--- a/_layouts/chapter.html
+++ b/_layouts/chapter.html
@@ -27,7 +27,7 @@ custom_css:
 {% assign sorted_pages = site.pages | sort:"chapter_num" %}
 {% assign thisch = false %}
 {% for p in sorted_pages %}
-	{% if thisch and p.layout ==  "chapter" %}
+	{% if thisch and page.layout != 'exercise' %}
 		Next chapter: <a href="{{site.baseurl}}{{p.url}}">{{ p.chapter_num }}. {{ p.title }}</a>
 		{% break %}
 	{% endif %}


### PR DESCRIPTION
@hawkrobe @ngoodman Exercise pages are linking to the conditioning exercises. 
<img width="916" alt="screen shot 2018-09-30 at 3 38 01 pm" src="https://user-images.githubusercontent.com/2654729/46265583-a5e68f80-c4dc-11e8-8246-8de0e35b095d.png">

This has to do with default behavior in `chapter` layouts. Fix should just check if .md file is a chapter or exercise.