### PR TITLE
Syntax error: lines 258-300, line 291.

### DIFF
--- a/chapters/inference-algorithms.md
+++ b/chapters/inference-algorithms.md
@@ -288,7 +288,7 @@ var makeLines = function(n, lines, prevScore){
 };
 
 var lineDist = Infer(
-  { method: 'MCMC', samples=50},
+  { method: 'MCMC', samples: 50},
   function(){
     var lines = makeLines(4, [], 0);
     var finalGeneratedImage = Draw(50, 50, true);


### PR DESCRIPTION
Changed "samples = 50" to "samples : 50" as per method syntax. Code runs correctly on website with correction.