### PR TITLE
conditional_dependence/readings

### DIFF
--- a/readings/conditional_dependence/readings
+++ b/readings/conditional_dependence/readings
@@ -1,0 +1,5 @@
+Adelson, Edward H., Perceptual Organization and the Judgment of Brightness, Science,  24 Dec 1993: Vol. 262, Issue 5142, pp. 2042-2044; DOI: 10.1126/science.8266102 https://pdfs.semanticscholar.org/972e/24f0070a1423994619a91d0adb13f2779892.pdf?_ga=2.142322290.1385134010.1575719564-2449010.1575719564 (visited 2019/12/22)
+
+Adelson, Edward H., Lightness Perception and Lightness Illusions. In The New Cognitive Neurosciences, 2nd ed., M. Gazzaniga, ed. Cambridge, MA: MIT Press, pp. 339-351, (2000). https://pdfs.semanticscholar.org/0fb3/9d213adc75ec24017b8a0c3939c8e513d6b7.pdf (visited 2019/12/22)
+
+Adelson, Edward H., On Seeing Stuff: The Perception of Materials by Humans and Machines, Proceedings of the. SPIE Vol. 4299, pp. 1-12, Human Vision and Electronic Imaging VI, B. E. Rogowitz; T. N. Pappas; Eds. (2001). http://persci.mit.edu/pub_pdfs/adelson_spie_01.pdf  (visited 2019/12/22)


### PR DESCRIPTION
the links to Edward H. Adelson's original papers describing the 'checkerboard illusion' disappeared. I readd the relevant papers and the active charge free links