### PR TITLE
Fixing two broken links

### DIFF
--- a/assets/bibliography.bib
+++ b/assets/bibliography.bib
@@ -317,9 +317,9 @@ url = {http://cvcl.mit.edu/SUNSeminar/GriffithsKempTenenbaum2008.pdf}
 	Author = {Hamrick, Jessica and Battaglia, Peter and Tenenbaum, Joshua B},
 	Booktitle = {Proceedings of the 33rd Annual Meeting of the Cognitive Science Society, Boston, MA},
 	Title = {Internal physics models guide probabilistic judgments about object dynamics},
-	Url = {http://web.mit.edu/pbatt/www/publications/HamrBattTene11CogSci33.pdf},
+	Url = {https://cogsci.mindmodeling.org/2011/papers/0350/paper0350.pdf},
 	Year = {2011},
-	Bdsk-Url-1 = {http://web.mit.edu/pbatt/www/publications/HamrBattTene11CogSci33.pdf}}
+	Bdsk-Url-1 = {https://cogsci.mindmodeling.org/2011/papers/0350/paper0350.pdf}}
 
 @inproceedings{Gerstenberg2012,
 	Author = {Gerstenberg, Tobias and Goodman, Noah D},

--- a/exercises/conditioning.md
+++ b/exercises/conditioning.md
@@ -67,7 +67,7 @@ viz.table(Infer({method:'enumerate'}, model));
 
 ## Exercise 2: Conditioning and Intervention
 
-In the earlier [Medical Diagnosis]({{site.baseurl}}/chapters/02-generative-models.html#example-causal-models-in-medical-diagnosis) section we suggested understanding the patterns of symptoms for a particular disease by changing the prior probability of the disease such that it is always true (also called the *do* operator).
+In the earlier [Medical Diagnosis]({{site.baseurl}}/chapters/generative-models.html#example-causal-models-in-medical-diagnosis) section we suggested understanding the patterns of symptoms for a particular disease by changing the prior probability of the disease such that it is always true (also called the *do* operator).
 
 ~~~~
 var lungCancer = flip(0.01);


### PR DESCRIPTION
Hi there. First of all, thanks for putting together such an awesome book! 

While reading through Chapter 2 and 3 of probmods, I noticed that two of the URLs are broken:
- On [Chapter 2 - Example: Intuitive Physics](https://probmods.org/chapters/generative-models.html#example-intuitive-physics), the PDF file for Hamrick et al. (2011) no longer exists on MIT's website. So I'm replacing it with an URL from COGSCI.
- On [Chapter 3 Exercise - Exercise 2: Conditioning and Intervention](https://probmods.org/exercises/conditioning.html#exercise-2-conditioning-and-intervention), the link back to Medical Diagnosis section in Chapter 2 is broken. This seems to be something that's supposed to be updated as part of the [cleanup several years ago](https://github.com/probmods/probmods2/commit/7b830bb8d4861c99b57e2618bb2576a05ef73cb2). Hopefully it isn't too late to fix it now :)

I've tested my changes on my local Jekyll session and verified that the website builds correctly. 

(On an unrelated note: the description of this GitHub repo links to [probmods.org/v2](https://probmods.org/v2), which no longer exists. Perhaps it's time to update that link as well? :D)